### PR TITLE
ci: use ubuntu-latest for security analysis

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,6 @@ concurrency:
 jobs:
   security:
     name: Security Analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: oxc-project/security-action@781317603d045c3eafc99daef653fcac77e12aa8 # v1.0.3


### PR DESCRIPTION
## Summary
- Switch the Security Analysis workflow runner from `ubuntu-slim` to `ubuntu-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)