### PR TITLE
chore: update packageManager to pnpm 11.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fuzz-oxc",
   "private": true,
+  "packageManager": "pnpm@11.0.4",
   "scripts": {
     "start": "cargo build --release && node main.js ./target/release/fuzzer"
   },


### PR DESCRIPTION
## Summary
- update the pnpm package manager pin to `pnpm@11.0.4`
- add missing pnpm package manager metadata where needed
- keep lockfiles unchanged to avoid unrelated dependency updates