### PR TITLE
chore: standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+style_edition = "2024"
+use_small_heuristics = "Max"
+use_field_init_shorthand = true
+reorder_modules = true
+merge_derives = true
+remove_nested_parens = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,7 @@ fn main() -> Result<(), String> {
         // .inspect_err(|err| panic!("{err:?}"))
         .unwrap_or_default();
 
-    Driver::default()
-        .run(path, &s1, source_type)
-        .map(|_| ())
-        .map_err(|err| panic!("{err:?}"))
+    Driver::default().run(path, &s1, source_type).map(|_| ()).map_err(|err| panic!("{err:?}"))
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -71,9 +68,7 @@ impl CompilerInterface for Driver {
     }
 
     fn codegen_options(&self) -> Option<CodegenOptions> {
-        Some(CodegenOptions {
-            ..CodegenOptions::default()
-        })
+        Some(CodegenOptions { ..CodegenOptions::default() })
     }
 }
 


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
